### PR TITLE
Set Engineering as the owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @coopnorge/platform-guild @coopnorge/engineering
+* @coopnorge/engineering
 
 /CODEOWNERS @coopnorge/security-guild

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,6 @@ metadata:
 spec:
   type: library
   lifecycle: experimental
-  owner: platform-guild
+  owner: engineering
   dependsOn:
     - component:default/github-action-techdocs


### PR DESCRIPTION
Until we have a team to handle developer productivity this should be
owned by Engineering.
