### PR TITLE
Add back `docs_dir` input

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -2,6 +2,10 @@
 on:
   workflow_call:
     inputs:
+      docs_dir:
+        type: string
+        required: false
+        default: docs/
       docker-compose-service:
         type: string
         required: false


### PR DESCRIPTION
`docs_dir` should not have been removed, it is used to set the
`edit_uri` for MkDocs.
