### PR TITLE
Update markdownlint config docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ default: true
 
 # MD007/ul-indent - Unordered list indentation
 MD007:
-  indent: 4  # This is what works in mkdocs
+  indent: 2  # This is what works in TechDocs
 
 MD033: false
 


### PR DESCRIPTION
The docs must match the default.
