### PR TITLE
Run the TechDocs workflow when build files changes

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -50,6 +50,9 @@ jobs:
               - '**/*.md'
               - catalog-info.yaml
               - mkdocs.yaml
+              - docker-compose.yaml
+              - docker-compose.yml
+              - docker-compose/Dockerfile
             markdown:
               - added|modified: '**/*.md'
   techdocs:


### PR DESCRIPTION
Repositories uses docker compose to control the image used in this
workflow. The workflow should also run when changes to docker compose
configuration files are detected. That way breaking changes are detected
when updates to the TechDocs image are proposed in a repository.
