### PR TITLE
Add to markdown filter image paths so it will be published

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -53,12 +53,12 @@ jobs:
               - docker-compose.yaml
               - docker-compose.yml
               - docker-compose/Dockerfile
+              - '**/*.jpg'
+              - '**/*.JPG'
+              - '**/*.png'
+              - '**/*.svg'
             markdown:
               - added|modified: '**/*.md'
-              - added|modified: '**/*.jpg'
-              - added|modified: '**/*.JPG'
-              - added|modified: '**/*.png'
-              - added|modified: '**/*.svg'
   techdocs:
     needs: ['setup']
     if: ${{ needs.setup.outputs.build == 'true' }}

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -55,6 +55,10 @@ jobs:
               - docker-compose/Dockerfile
             markdown:
               - added|modified: '**/*.md'
+              - added|modified: '**/*.jpg'
+              - added|modified: '**/*.JPG'
+              - added|modified: '**/*.png'
+              - added|modified: '**/*.svg'
   techdocs:
     needs: ['setup']
     if: ${{ needs.setup.outputs.build == 'true' }}


### PR DESCRIPTION
If just image updated, docs not published -> https://github.com/coopnorge/member-team/actions/runs/4314736980/jobs/7528165556#step:3:52

Not sure if it's critical to add images paths under markdown filter but let me know