### PR TITLE
feat: Support running techdocs for new devtools structure

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -55,6 +55,8 @@ jobs:
               - docker-compose.yml
               - devtools/Dockerfile
               - docker-compose/Dockerfile
+              - devtools/techdocs.Dockerfile
+              - docker-compose/techdocs.Dockerfile
               - "${{ inputs.docs_dir }}**/*.JPG"
               - "${{ inputs.docs_dir }}**/*.jpg"
               - "${{ inputs.docs_dir }}**/*.md"

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -53,6 +53,8 @@ jobs:
               - mkdocs.yaml
               - docker-compose.yaml
               - docker-compose.yml
+              - devtools/techdocs.yaml
+              - docker-compose/techdocs.yaml
               - devtools/Dockerfile
               - docker-compose/Dockerfile
               - devtools/techdocs.Dockerfile


### PR DESCRIPTION
The new devtools structure uses docker-compose includes to include partial docker compose files and dedicated techdocs.Dockerfile.